### PR TITLE
cluster: Make sure post-config finishes with no error

### DIFF
--- a/tasks/create_repositories.yml
+++ b/tasks/create_repositories.yml
@@ -20,6 +20,7 @@
     force_basic_auth: yes
     status_code: 201
   register: repository_created_response
+  run_once: true
   when: repository_exists_response.json.count == 0
 
 - debug:


### PR DESCRIPTION
I have a cluster of 3 pulp nodes and I want to install galaxy_ng on all
of them. Currently play finishes with error because the creation of the
repository is tried 3 times (work on the first node it gets to fails on
the two other ones).

This commit makes sure it is run only on one node and finishes with no
error.