### PR TITLE
cluster: Make sure post-config finishes with no error

### DIFF
--- a/tasks/create_repositories.yml
+++ b/tasks/create_repositories.yml
@@ -41,6 +41,7 @@
     force_basic_auth: yes
     status_code: 202
   register: distribution_created_response
+  run_once: true
   when: repository_exists_response.json.count == 0
 
 - debug:


### PR DESCRIPTION
Same issue as #1 - Simply that the second time I run it this was skipped because the criteria here is that the repository doesn't exist. (I think it should be distribution) -

### When does that happen

I have the following inventory:

```
[database]
database01

[redis]
redis01

[haproxy]
haproxy01

[pulp]
pulp[01:03]
```

and the following playbook:

```
- hosts: pulp
  roles:
    - pulp
    - pulp_database
    - pulp_workers
    - pulp_resource_manager
    - pulp_webserver
    - pulp_content
  environment:
    DJANGO_SETTINGS_MODULE: pulpcore.app.settings

- hosts: pulp
  tasks:
    - name: Configure Galaxy Backend
      include_role:
        name: chouseknecht.ansible_galaxy_config
```

When this role is run this way we end up with the following situation (certainly due to a race)

```
TASK [chouseknecht.ansible_galaxy_config : Create repository] ****************************************************************************************************************
ok: [pulp01] => changed=false                                                                                                                                                 
  allow: GET, POST, HEAD, OPTIONS                                                                                                                                             
  connection: close                                                                                                                                                           
  content_length: '431'                                                                                                                                                       
  content_type: application/json                                                                                                                                              
  cookies: {}                                                                                                                                                                 
  cookies_string: ''                                                                                                                                                          
  date: Mon, 15 Jun 2020 20:51:53 GMT                                                                                                                                         
  elapsed: 1                                                                                                                                                                  
  json:                                                                                                                                                                       
    description: Certified content repository                                                                                                                                 
    latest_version_href: /pulp/api/v3/repositories/ansible/ansible/662c457b-931e-4f2f-b986-1d0691450eb0/versions/0/                                                           
    name: automation-hub                                                                                                                                                      
    pulp_created: '2020-06-15T20:51:52.536893Z'                                                                                                                               
    pulp_href: /pulp/api/v3/repositories/ansible/ansible/662c457b-931e-4f2f-b986-1d0691450eb0/                                                                                
    versions_href: /pulp/api/v3/repositories/ansible/ansible/662c457b-931e-4f2f-b986-1d0691450eb0/versions/                                                                   
  location: http://127.0.0.1:24817/pulp/api/v3/repositories/ansible/ansible/662c457b-931e-4f2f-b986-1d0691450eb0/                                                             
  msg: OK (431 bytes)                                                                                                                                                         
  redirected: false                                                                                                                                                           
  server: gunicorn/20.0.4                                                                                                                                                     
  status: 201                                                                                                                                                                 
  url: http://127.0.0.1:24817/pulp/api/v3/repositories/ansible/ansible/                                                                                                       
  vary: Accept, Cookie                                                                                                                                                        
  x_frame_options: SAMEORIGIN                                                                                                                                                 
fatal: [pulp02]: FAILED! => changed=false                                                                                                                                     
  allow: GET, POST, HEAD, OPTIONS                                                                                                                                             
  connection: close                       
  content: '{"name":["This field must be unique."]}'                                   
  content_length: '39'                
  content_type: application/json
  date: Mon, 15 Jun 2020 20:51:53 GMT                                                  
  elapsed: 1                                                                                                                                                                  
  json:                 
    name:                                                                              
    - This field must be unique.                                                                                                                                              
  msg: 'Status code was 400 and not [201]: HTTP Error 400: Bad Request'                                                                                                       
  redirected: false                                                                                                                                                           
  server: gunicorn/20.0.4                                                              
  status: 400                                                                          
  url: http://127.0.0.1:24817/pulp/api/v3/repositories/ansible/ansible/                                                                                                       
  vary: Accept, Cookie                     
  x_frame_options: SAMEORIGIN
fatal: [pulp03]: FAILED! => changed=false                                                                                                                                     
  allow: GET, POST, HEAD, OPTIONS                                                                                                                                             
  connection: close
  content: '{"name":["This field must be unique."]}'
  content_length: '39'
  content_type: application/json
  date: Mon, 15 Jun 2020 20:51:53 GMT
  elapsed: 1
  json:
    name:
    - This field must be unique.
  msg: 'Status code was 400 and not [201]: HTTP Error 400: Bad Request'
  redirected: false
  server: gunicorn/20.0.4
  status: 400
  url: http://127.0.0.1:24817/pulp/api/v3/repositories/ansible/ansible/
  vary: Accept, Cookie
  x_frame_options: SAMEORIGIN                               
```

This is what the `run_once` from is avoiding, with `run_once` the task will be run only in a single node.

While I agree that the playbook could be updated to the following so the issue does not happen, I feel its still better to have the role handle the situation graciously rather than failing.

```
- hosts: localhost
  tasks:
    - name: Configure Galaxy Backend
      include_role:
        name: chouseknecht.ansible_galaxy_config
```