### PR TITLE
continue to create a distribution until success

### DIFF
--- a/tasks/create_distribution.yml
+++ b/tasks/create_distribution.yml
@@ -4,8 +4,8 @@
       url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}/pulp/api/v3/distributions/ansible/ansible/"
       method: POST
       body:
-        base_path: "{{ main_item.base_path }}-{{ 10000 | random }}"
-        name: "{{ main_item.name }}-{{ 10000 | random }}"
+        base_path: "{{ main_item.base_path }}"
+        name: "{{ main_item.name }}"
         repository: "http://{{ pulp_api_host }}:{{ pulp_api_port }}{{ repository_created_response.json.pulp_href }}"
       body_format: json
       user: "{{ pulp_admin_username }}"

--- a/tasks/create_distribution.yml
+++ b/tasks/create_distribution.yml
@@ -1,0 +1,32 @@
+- block:
+  - name: Create distribution
+    uri:
+      url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}/pulp/api/v3/distributions/ansible/ansible/"
+      method: POST
+      body:
+        base_path: "{{ main_item.base_path }}-{{ 10000 | random }}"
+        name: "{{ main_item.name }}-{{ 10000 | random }}"
+        repository: "http://{{ pulp_api_host }}:{{ pulp_api_port }}{{ repository_created_response.json.pulp_href }}"
+      body_format: json
+      user: "{{ pulp_admin_username }}"
+      password: "{{ pulp_default_admin_password }}"
+      force_basic_auth: yes
+      status_code: 202
+    register: distribution_created_response
+    run_once: true
+
+  - name: Wait until the distribution task is complete
+    uri:
+      url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}{{ distribution_created_response.json.task }}"
+      user: "{{ pulp_admin_username }}"
+      password: "{{ pulp_default_admin_password }}"
+      force_basic_auth: yes
+    register: distribution_created_task_response
+    until: distribution_created_task_response.json.state != 'waiting'
+    delay: 2
+    retries: 60
+
+  - debug:
+      msg: "Task for creating distribution did not reach a successful state. {{ distribution_created_task_response }}"
+    when: distribution_created_task_response.json.state != 'completed'
+  when: repository_exists_response.json.count == 0

--- a/tasks/create_repositories.yml
+++ b/tasks/create_repositories.yml
@@ -23,7 +23,8 @@
   run_once: true
   when: repository_exists_response.json.count == 0
 
-- debug:
+- name: Repository creation task results
+  debug:
     msg: "{{ repository_created_response.json }}"
   when: repository_exists_response.json.count == 0
 
@@ -33,7 +34,7 @@
   delay: 2
   retries: 60
 
-- name: Repository creation task
+- name: Distribution creation task
   debug:
     msg: "{{ distribution_created_response.json }}"
   when: repository_exists_response.json.count == 0

--- a/tasks/create_repositories.yml
+++ b/tasks/create_repositories.yml
@@ -27,23 +27,13 @@
     msg: "{{ repository_created_response.json }}"
   when: repository_exists_response.json.count == 0
 
-- name: Create distribution
-  uri:
-    url: "http://{{ pulp_api_host }}:{{ pulp_api_port }}/pulp/api/v3/distributions/ansible/ansible/"
-    method: POST
-    body:
-      base_path: "{{ main_item.base_path }}"
-      name: "{{ main_item.name }}"
-      repository: "http://{{ pulp_api_host }}:{{ pulp_api_port }}{{ repository_created_response.json.pulp_href }}"
-    body_format: json
-    user: "{{ pulp_admin_username }}"
-    password: "{{ pulp_default_admin_password }}"
-    force_basic_auth: yes
-    status_code: 202
-  register: distribution_created_response
-  run_once: true
-  when: repository_exists_response.json.count == 0
+- name: Continue to create a distribution until it succeeds
+  include: create_distribution.yml
+  until: distribution_created_task_response.json.state == 'completed'
+  delay: 2
+  retries: 60
 
-- debug:
+- name: Repository creation task
+  debug:
     msg: "{{ distribution_created_response.json }}"
   when: repository_exists_response.json.count == 0


### PR DESCRIPTION
* We have observed that the task spawned to create a distribution can
fail. The task is assigned a worker, so presumably pulp workers are up
and healthy, yet the task still fails. To observed failure is that the
task gets marked 'canceled'. This PR presumes that a task that is marked
'completed' results in a distribution being sucessfully created.


related to https://github.com/ansible/galaxy_ng/issues/226