### PR TITLE
Make sure json key is available

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     status_code: 200
   register: result
   until: >
+    'json' in result and
     result.json.database_connection.connected == true and
     result.json.redis_connection.connected == true and
     result.json.online_workers | map(attribute='name') | select('match', '^resource-manager$') | list | count > 0 and


### PR DESCRIPTION
This should prevent against this error `'dict object' has no attribute 'json'`

I am still gathering more information but the added change should work around a random failure faced when trying to execute the conditionals.