### PR TITLE
Add ability to specify validate_certs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ pulp_user: pulp
 pulp_default_admin_password: password
 pulp_api_host: 127.0.0.1
 pulp_api_port: 24817
+pulp_api_validate_certs: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     password: "{{ pulp_default_admin_password }}"
     force_basic_auth: yes
     status_code: 200
+    validate_certs: "{{ pulp_api_validate_certs }}"
   register: result
   until: >
     'json' in result and


### PR DESCRIPTION
Allow specifying the `pulp_api_validate_certs` variable to control if
the SSL certificate from the Pulp server should be validated or not.